### PR TITLE
Add annual-cloud-data-update skill (yearly metadata refresh workflow)

### DIFF
--- a/.claude/skills/annual-cloud-data-update/SKILL.md
+++ b/.claude/skills/annual-cloud-data-update/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: annual-cloud-data-update
+description: >-
+  Update the real-time-cloud Cloud_Region_Metadata.csv with a new year of cloud-provider
+  sustainability data (PUE, WUE, carbon-free / renewable energy %, grid carbon intensity)
+  when AWS, Google, Microsoft Azure or Oracle publish their annual reports. Use this whenever
+  the user wants to add or refresh a year of cloud region metadata, extract PUE/WUE/CFE from a
+  provider sustainability report, reconcile a provider's disclosures into this dataset, or open
+  the annual update PRs. Providers publish on a rolling schedule (Azure ~May, Google ~June,
+  Amazon ~July, Oracle ~Dec), so this is typically run several times a year as each vendor lands.
+---
+
+# Annual cloud region metadata update
+
+This repo (`Green-Software-Foundation/real-time-cloud`) normalises annual sustainability metadata
+from the major cloud providers into one CSV, `Cloud_Region_Metadata.csv`, on the schema described
+in `Cloud_Region_Metadata_specification.md`. Each year the providers publish a new year of data and
+this file gets extended. This skill captures how to do that cleanly, because the work is fiddly and
+several mistakes are easy to make and hard to spot.
+
+Read this file, then read the per-provider reference for whichever vendor(s) you're updating:
+`references/aws.md`, `references/google.md`, `references/azure.md`, `references/oracle.md`. The two
+output docs have templates: `references/metrics-doc-template.md` and `references/gaps-report-template.md`.
+
+## The two rules that matter most
+
+**1. Additive only.** Never modify or delete a row for a year that's already published. Providers
+sometimes *restate* older numbers or *blank* a value in a later snapshot — do not chase those into
+the historical rows. A correct update has `removed: 0` in the diff check below. If the user asks to
+fix an older year, do it as an explicit, separate decision, not as a side effect.
+
+**2. Per-region physical data only — not the global market claim.** Most providers claim "100%
+renewable/carbon-free" on a company-wide, market-based basis that nets purchases across grids that
+aren't electrically connected. That claim is **not useful per-region** and must not populate the
+carbon-free-energy columns. Specifically:
+- `provider-cfe-hourly` / `provider-cfe-annual` are for *location-based, per-region* carbon-free
+  energy. Only fill them with a genuine per-region figure (e.g. Google's hourly CFE, Oracle's
+  per-region renewable %). Do **not** set a uniform `1.0` because the provider claims global 100%.
+- `provider-carbon-intensity-market-annual` is the dedicated market column. It's acceptable to set
+  it to `0` **only** where the provider publishes a genuine *per-region* 100% list (AWS matches
+  energy within specific grids and names those regions). Carry that per-region, never as a uniform
+  value.
+
+When in doubt about whether a figure is per-region-physical or a global-market claim, leave it blank
+and flag it for the user — a blank is honest, an invented number is not.
+
+## Workflow: three phases
+
+The work runs in three phases — **extract → merge → gaps** — because the value of this project isn't
+just the merged table, it's making the providers' metrics *comparable*. If you jump straight to the
+CSV you lose the definitions, and the definitions are where the incomparability hides (one vendor's
+"PUE" is a 12-month rolling average across 88% of sites; another's is Jan–Dec for operated sites; a
+"100% renewable" claim can be global-market or per-grid). So capture the definitions first, merge only
+what genuinely fits the schema, and write up the gaps.
+
+Outputs land in `metrics/<year>/`: one `<vendor>-<year>-metrics.md` per provider, and one shared
+`gaps-<year>.md`.
+
+### Phase A — Extract data *and definitions* into `<vendor>-<year>-metrics.md`
+For each vendor, read the source report(s) (see the per-provider reference for exact URLs) and produce
+a standalone Markdown doc that a reader could use *without* the original PDF. For every metric capture:
+- **Metric** and the **value(s)** per region/scope, with units.
+- **The vendor's own definition, quoted** (e.g. AWS: PUE/WUE "for data centers operated by AWS between
+  January 1 and December 31 of each year"). Quote it verbatim — the definition is the point.
+- **Reporting period — exact dates, not just a year label**: AWS and Google report calendar year
+  (Jan–Dec); **Azure (FY Jul–Jun) and Oracle (FY Jun–May) report fiscal years that end mid-calendar-year**,
+  so their "2025" ends ~mid-2025 and is a different window than a calendar-2025 figure. Also the
+  boundary (operated vs owned+leased, % of sites covered, rolling-12-month vs annual). Record the exact
+  period per metric — sometimes different tables in one report use different bases.
+- **Method**: location-based vs market-based; hourly vs annual; per-region vs macro/fleet-wide.
+- Anything that has **no home in the RTC schema** (e.g. Oracle's tCO₂e/$USD, AWS embodied carbon) —
+  record it so the gaps report can note it.
+
+Follow the standard `metrics-doc` template in `references/metrics-doc-template.md`. This doc is the
+input to both later phases; get it right and the merge is mechanical.
+
+### Phase B — Merge conforming metrics into the metadata table
+Only metrics whose definition genuinely matches the schema column's intended meaning get merged (see
+`Cloud_Region_Metadata_specification.md` for what each column means, and rule 2 above for the
+CFE/market distinction). If a vendor's metric almost-but-not-quite fits, prefer leaving the cell blank
+and recording the mismatch in the gaps report over forcing a number in. The mechanics (build script,
+carry-forward, verify) are steps 1–5 below.
+
+### Phase C — Write `gaps-<year>.md`
+A cross-vendor alignment report: for each metric in the schema, tabulate how each vendor defines and
+reports it, then call out what each vendor should change to make it comparable. This directly serves
+the project's mission of lobbying providers toward a common definition. See
+`references/gaps-report-template.md` for the structure and the recurring gaps to check every year
+(fiscal-vs-calendar year, PUE boundary/coverage, WUE availability, location-vs-market CFE, per-region
+vs macro/fleet reporting, missing per-region grid data).
+
+---
+
+## Merge mechanics (Phase B, step by step)
+
+### 1. Set up a clean working base
+The authoritative state is `upstream/main` (GSF). Local `main` and the fork's `Dev` drift behind it.
+```
+git fetch upstream && git fetch origin
+git checkout main && git merge --ff-only upstream/main    # if local main is behind and not ahead
+git checkout -b <year>-<provider>-update upstream/Dev      # PRs target Dev; Dev == main data-wise
+```
+Confirm `Dev` and `main` hold identical data files before branching off `Dev` (they usually do; the
+few `main`-only commits are release merges / issue templates). One provider per branch/PR keeps
+review clean, unless the user wants them combined.
+
+### 2. Find the source data
+Each provider has a tracking issue where the report link (and sometimes an extracted table) is
+posted — check open issues labelled `action item` (e.g. AWS #158, Google #159, Azure #161, Oracle
+#86). The report itself is the source of truth; a pasted table in an issue is a convenience. See the
+per-provider reference for exact URLs, which page/table to read, and the region-name→region-code
+mapping.
+
+### 3. Build the new rows
+Prefer a small, explicit, reviewable Python script that encodes the source table and writes rows,
+over the older scraper scripts in `code/` (`aws-data-update.py` scrapes a popup and has historically
+mislabelled columns; trust the report/issue table instead). `gcp-data-update.py` pulling from the
+`region-carbon-info` repo is reliable for Google's CFE/grid data.
+
+Carry forward slowly-changing metadata (`cfe-region`, `em-zone-id`, `wt-region-id`, `location`,
+`geolocation`, and grid carbon intensity) from the region's most recent prior year — no new
+Electricity Maps / WattTime lookup happens here. Only populate PUE/WUE/CFE for the new year where
+the provider actually disclosed it.
+
+**New regions appear every year** (each provider launches several). A region with disclosed data but
+no prior row has nothing to carry forward — add it fresh rather than skipping it: **geocode a
+city-level geolocation** (`geopy` Nominatim on the city name, rounded to 4 dp — the dataset uses
+city-level, not exact datacenter coordinates), set `cfe-region`/`em-zone-id` from the country/grid
+(the Electricity Maps zone), fill the disclosed PUE/WUE/CFE, and leave `wt-region-id` + grid carbon
+intensity blank with a note that they need a WattTime / Electricity Maps lookup. Adding the region now
+with partial metadata is better than dropping it — the grid columns can be filled when the lookup runs.
+
+**Water (`total-water-input`).** Some providers report a per-region annual water **withdrawal** in
+litres (AWS does, on each fact sheet). That maps to `total-water-input`. Watch the reporting boundary:
+where a provider reports by **country** but has several regions there, allocate/interpolate — if the
+regions are reported separately (AWS India: Mumbai/Hyderabad) use each; if combined (AWS Japan =
+Tokyo+Osaka together) allocate to the primary region and leave the other blank (or split on a stated
+basis), and document the choice. Convert gallons to litres where needed.
+
+**Grid data (Electricity Maps / WattTime).** `em-zone-id`/`wt-region-id` are the lookup keys; the actual
+`grid-carbon-intensity-*` values come from those services. Electricity Maps publishes yearly zone data
+but via an **account-gated free portal** (`app.electricitymaps.com/datasets`, ~5 downloads) — not a
+fetchable URL; WattTime marginal data is **API-gated** (credentials). So for a brand-new region set the
+`em-zone-id` and leave grid carbon blank, and flag it for whoever has portal/API access to fill (the
+project has done this before — see issue #86). Don't block the row on it.
+
+**Critical file-format details** (getting these wrong makes the diff look enormous):
+- The file is **CRLF**. Always write with `df.to_csv(path, index=False, lineterminator="\r\n")`.
+- Read with `dtype=str` so existing numeric strings aren't reformatted.
+- Sort `year` descending, then provider, then region (matches the repo convention).
+- The `geolocation` field contains a comma inside quotes, so **never parse this CSV with `awk -F,`**
+  — it mis-splits every subsequent column. Use Python's `csv` module or pandas.
+
+### 4. Verify before committing
+```
+python3 -c "import csv;r=list(csv.reader(open('Cloud_Region_Metadata.csv')));n=len(r[0]);\
+print('cols',n,'bad',[i for i,x in enumerate(r) if len(x)!=n][:5])"          # expect 24 cols, no bad rows
+grep -c $'\r' Cloud_Region_Metadata.csv                                        # CRLF preserved on every line
+diff <(git show upstream/Dev:Cloud_Region_Metadata.csv|sort) <(sort Cloud_Region_Metadata.csv)|grep -c '^<'   # MUST be 0 (additive)
+```
+Then spot-check a handful of rows against the source report (right PUE in the PUE column, right WUE
+in WUE, CFE where expected, market column per the rules above).
+
+### 5. Regenerate the estimate, sanity-check it, and update the README
+The published estimate table is the **complete best-guess** current-year table. Its purpose: be *the*
+central resource so that anyone who needs a number to use today gets one consistent best guess, instead
+of everyone inventing their own. Every region gets a row and every tracked metric is filled (from the
+region's own history where available, otherwise a regional best guess). Generate it with:
+```
+python3 code/complete_estimate.py Cloud_Region_Metadata.csv <next-year>   # e.g. 2026
+```
+Fill rules that matter:
+- **Grid carbon intensity** is a physical grid property → fill from the same `em-zone-id` / continent
+  (across providers is fine — it's the same grid).
+- **Provider-specific metrics** (PUE, WUE, CFE %, market carbon, water) fill **only from the same
+  provider's** regional data — **never estimate one provider's metric from another's**. If a provider
+  doesn't report a metric anywhere (AWS/Azure CFE %, Google/Azure water, Google WUE), leave it blank.
+- **Keep it conservative**: project only PUE/WUE/CFE, one *capped* step from the latest reported value;
+  **carry forward** the noisy annual measurements (grid/consumption-hourly carbon, market carbon, water).
+  Extrapolating a linear trend on those produces nonsense — a low-carbon grid trending to 0, CFE to 1.0.
+- The never-reported EU-EED fields (`total-ICT-energy-consumption-annual`, `renewable-energy-*`) stay blank.
+
+**Then sanity-check the estimate against the reported data — always:**
+```
+python3 code/sanity_check_estimate.py Cloud_Region_Metadata.csv Cloud_Region_Metadata_estimate.csv
+```
+It flags out-of-range absolutes (PUE < 1.04 / > 2, CFE outside 0–1, negative carbon), big jumps from a
+region's latest reported value, regional-fill outliers, and coverage gaps. Aim for `TOTAL flags: 0`;
+investigate any flag — some large moves are legitimate (a new grid, a restated value), but most point to
+an over-eager extrapolation to fix. This is how the "central best guess" stays trustworthy.
+
+**Keep the reported table (`Cloud_Region_Metadata.csv`) clean — never fill best-guesses into it; the
+estimate table is the only place guesses belong.** (`estimate_current_region_metadata.py` is the older
+trend-only estimator, kept for reference/testing; it leaves gaps blank.) Update the "Cloud Providers"
+paragraph in `README.md` to state the latest real year and the projected year.
+
+### 6. Open the PR and update the tracking issue
+Base the PR on `Dev`. Include the CSV/estimate/README changes **and** the phase-A `metrics/<year>/`
+docs and the phase-C `gaps-<year>.md` — they're deliverables, and they're the evidence for every
+merge decision and caveat. In the body, state the sources (with links), the per-provider column
+mapping, and every caveat/approximation. Comment on the provider's tracking issue with what landed and
+what's still missing. Commit trailer: `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`;
+PR-body trailer: `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+
+### 7. Archive the source documents
+Providers periodically move or delete these files (the AWS popup, gstatic-hosted Google reports and
+Oracle's data sheets have all changed URLs). Save the PDFs you used to `sources/<data-year>/<provider>/`
+with a `sources/README.md` manifest (document each file's source URL, retrieval date, and a **gaps table**
+for documents still needed — e.g. Oracle's CY report, Electricity Maps/WattTime data, prior-year fact
+sheets). Download prior years too where the URLs are still live. This is bulky (~180 MB/year of PDFs);
+keep it on its own branch/PR and flag **Git LFS or an external release-asset store** vs a plain commit so
+the WG decides before merging binaries into history.
+
+## Tooling notes
+- PDFs: `pdfplumber` (reports) and `openpyxl` (Google-Sheet exports of working data). A working
+  `venv` may have a Python-version/site-packages mismatch — if `import` fails, run the system
+  `python3` with `PYTHONPATH=code/venv/lib/python3.XX/site-packages` pointing at wherever the
+  packages actually installed.
+- Google Sheets shared by the user export as CSV/XLSX via
+  `https://docs.google.com/spreadsheets/d/<ID>/export?format=xlsx`.
+- The scratchpad dir (per session) is the place for these one-off builder scripts, not the repo.
+
+## Outputs of a full run
+A complete update produces, and the PR(s) should include: new **reported** rows in
+`Cloud_Region_Metadata.csv` (clean, real data only); the regenerated **complete estimate**
+`Cloud_Region_Metadata_estimate.csv` (best-guess, every cell filled, **sanity-checked** vs reported); the phase-A
+`metrics/<year>/<vendor>-<year>-metrics.md` docs and phase-C `metrics/<year>/gaps-<year>.md`; a README
+update; and the `sources/<year>/` archive (own branch). Reported table clean, estimate table filled —
+never mix the two.
+
+## What each provider gives you (summary — details in the references)
+| Provider | Per-region disclosed | Notes |
+|----------|----------------------|-------|
+| AWS      | PUE, WUE, water withdrawal (per-region); per-grid 100%-renewable list | `references/aws.md` — **~32 per-region PDF fact sheets** to download + process individually; friendly-name→code map; market=0 only for listed regions; regional-average PUE for newer regions |
+| Google   | hourly CFE + grid carbon (region-carbon-info repo); per-datacenter PUE (report PDF) | `references/google.md` — annual CFE left blank; don't use the 100% claim |
+| Azure    | only macro-regional (Americas/APAC/EMEA), fiscal-year PUE/WUE; detailed data fact sheet PDF for definitions | `references/azure.md` — map by continent; no per-region since 2022 |
+| Oracle   | renewable % per region; PUE (CY report); grid via Electricity Maps | `references/oracle.md` — key→identifier map; gov regions inherit co-located grid |
+| Others   | IBM/Alibaba/OVHcloud publish only fleet-wide PUE — not usable per-region | skip unless per-region data appears; still note them in the gaps report |

--- a/.claude/skills/annual-cloud-data-update/references/aws.md
+++ b/.claude/skills/annual-cloud-data-update/references/aws.md
@@ -1,0 +1,84 @@
+# AWS (Amazon Web Services)
+
+**Cadence:** Amazon publishes its sustainability report ~July; the report covers the prior calendar
+year. Tracking issue is usually where the extracted PUE/WUE table gets pasted (e.g. #158 for the
+2025 report).
+
+## Sources
+- **Per-region sustainability fact sheets (the primary source — download and process all of them):**
+  the AWS cloud page links **~32 per-region PDF fact sheets** at
+  `https://sustainability.aboutamazon.com/aws-sustainability-fact-sheets/aws-fact-sheet-<location>.pdf`.
+  Discover the current list by fetching
+  `https://sustainability.aboutamazon.com/products-services/aws-cloud` and grepping the HTML for
+  `aws-fact-sheet-[a-z-]+\.pdf` (a couple are language variants like `-france-french`, `-japan-japanese`
+  — same data). Download each and extract with `pdfplumber`. Page 1 of each carries a
+  `AWS <Region> 20XX 20XX 20XX` table with **Average PUE** and **Average WUE (L/kWh)** per year, plus
+  the metric definition (quote it — e.g. *"Power Usage Effectiveness (PUE) and Water Usage
+  Effectiveness (WUE), in liters per kilowatt-hour, for data centers operated by AWS between January 1
+  and December 31 of each year"*) and per-region carbon-free-energy / water / embodied-carbon narrative.
+  Process each fact sheet individually into the `aws-<year>-metrics.md` summary (one row per region +
+  the shared definitions). Fact-sheet file name → AWS region: they're named by *location*
+  (virginia, ohio, oregon, california, ireland, frankfurt via germany, etc.), so map location→region
+  using the friendly-name table below.
+- **PUE + WUE per region (cross-check):** the popup table on the same page under `#increasing-efficiency`
+  (columns `PUE 2022 | PUE 2023 | PUE 2024 | PUE 2025 | WUE 2024 | WUE 2025`) usually matches the fact
+  sheets and is what gets pasted into the tracking issue. Use it to sanity-check the fact-sheet
+  extraction. **Do not** rely on `code/aws-data-update.py`: it scrapes this popup and has mislabelled
+  PUE as WUE in the past.
+- **Metric methodology:** `https://sustainability.aboutamazon.com/pue-methodology.pdf` and
+  `renewable-energy-methodology.pdf` for the full definitions to cite in the metrics doc.
+- **Global figures** (for the README / sanity checks): the report states global PUE and a global WUE
+  series, and that Amazon "matched 100% of electricity with renewable energy" for N years running.
+
+## Columns to populate
+- `power-usage-effectiveness` — per-region PUE for the new year, where the table shows one. Blank if
+  the table shows `--` for that region/year.
+- `water-usage-effectiveness` — per-region WUE for the new year, where shown. Note AWS historically
+  used a single global WUE (e.g. 0.18) applied to all regions; newer years give real per-region WUE
+  and blanks. Use exactly what the table shows; don't carry the old global default into a new year.
+- `provider-carbon-intensity-market-annual` — **per region**, carried forward from the region's most
+  recent prior year. AWS names a specific set of regions where it matches energy *within the grid*
+  (100% renewable); those regions have `0` and the rest are blank. This is legitimate per-region data
+  — keep the per-region pattern, never a uniform `0` across all regions.
+- `total-water-input` — each fact sheet states a per-region annual water **withdrawal** ("In 20XX, AWS
+  withdrew N litres of water in <place>"); convert gallons→litres where needed. Boundary handling: map
+  single-region countries directly; where a country has several regions reported **separately** (India:
+  Mumbai/Hyderabad) use each; where **combined** (Japan = Tokyo+Osaka together) allocate to the primary
+  region and leave the other blank, documenting the interpolation.
+- **Regional-average fallback** — AWS does not give every region an individual PUE/WUE. Newer/smaller
+  regions show a regional average instead (**AWS Europe** ~1.11 for Milan, Zurich; **AWS Asia Pacific**
+  ~1.25 for Seoul, Malaysia, New Zealand; **AWS North America design** ~1.14/0.08 for US locations
+  without a named region). Prefer leaving the per-region PUE/WUE **blank** rather than writing the
+  regional average into a per-region cell (record the average in the metrics doc); still add the row so
+  its water/grid data is captured.
+- Carry forward `cfe-region`, `em-zone-id`, `wt-region-id`, `location`, `geolocation`, and grid
+  carbon intensity from the prior year's row.
+
+## Region friendly-name → region-code map
+```
+Europe (Frankfurt) eu-central-1     Europe (Ireland) eu-west-1        Europe (London) eu-west-2
+Europe (Paris) eu-west-3            Europe (Spain) eu-south-2         Europe (Stockholm) eu-north-1
+Europe (Milan) eu-south-1          Europe (Zurich) eu-central-2      Middle East (Bahrain) me-south-1
+Middle East (Tel Aviv) il-central-1 Middle East (UAE) me-central-1   Africa (Cape Town) af-south-1
+Asia-Pacific (Bangkok) ap-southeast-7*  Asia-Pacific (Hyderabad) ap-south-2  Asia-Pacific (Jakarta) ap-southeast-3
+Asia-Pacific (Melbourne) ap-southeast-4  Asia-Pacific (Mumbai) ap-south-1    Asia-Pacific (Osaka) ap-northeast-3
+Asia-Pacific (Singapore) ap-southeast-1  Asia-Pacific (Sydney) ap-southeast-2  Asia-Pacific (Tokyo) ap-northeast-1
+Asia-Pacific (Hong Kong) ap-east-1  Asia-Pacific (Seoul) ap-northeast-2  China (Ningxia) cn-northwest-1
+China (Beijing) cn-north-1         South America (Sao Paulo) sa-east-1  Canada (Central) ca-central-1
+Canada (West) ca-west-1            U.S. East (Northern Virginia) us-east-1  U.S. East (Ohio) us-east-2
+U.S. West (Northern California) us-west-1  U.S. West (Oregon) us-west-2  GovCloud (US East) us-gov-east-1
+GovCloud (US West) us-gov-west-1
+```
+`*` A friendly name with **no existing row** in the dataset is a **new region** (AWS adds several each
+year — e.g. Bangkok `ap-southeast-7` launched early 2025). New regions have no prior metadata to carry
+forward, so add them fresh: geocode a **city-level geolocation** (e.g. `geopy` Nominatim on the city
+name → `13.7525,100.4935` for Bangkok), set `cfe-region` to the country/grid and `em-zone-id` to the
+Electricity Maps zone (`TH` for Thailand), fill the disclosed PUE/WUE, and leave `wt-region-id` and grid
+carbon intensity blank with a note that they need a WattTime / Electricity Maps lookup. Don't skip a
+new region just because grid data isn't available yet — add it with what's known.
+
+## Gotchas
+- Only add rows for regions the table actually discloses for the new year. AWS restates and blanks
+  older years on the live page — leave the historical rows alone (rule 1).
+- 100%-renewable ≠ every region has `market = 0`; it's the specific per-grid list. Carry the prior
+  year's per-region market value forward rather than reasoning it out afresh.

--- a/.claude/skills/annual-cloud-data-update/references/azure.md
+++ b/.claude/skills/annual-cloud-data-update/references/azure.md
@@ -1,0 +1,78 @@
+# Microsoft Azure
+
+**Cadence:** Microsoft publishes its Environmental Sustainability Report ~May. Tracking issues: #161, #112.
+
+## Timescale — read this before mapping any year
+Microsoft reports on a **fiscal year that runs July 1 – June 30**, so its periods **end in the middle
+of the calendar year**, not at Dec 31:
+- **FY2025 = July 1 2024 – June 30 2025** (ends mid-2025)
+- **FY2024 = July 1 2023 – June 30 2024** (ends mid-2024)
+
+This matters because AWS and Google report **calendar year** (Jan 1 – Dec 31). So Microsoft's "FY25"
+and everyone else's "2025" cover **different windows** — FY25 is mostly H2-2024 + H1-2025. When you
+merge Azure, map `FY(N) → calendar year N` (FY25→2025) to keep one column per nominal year, but this
+is a **lossy approximation**: record the exact period (`Jul 2024–Jun 2025`) in `azure-<year>-metrics.md`
+and call it out explicitly in `gaps-<year>.md` as a real comparability gap — a customer comparing a
+2025 Azure region to a 2025 AWS region is comparing offset time periods. (Oracle has the same issue: its
+fiscal year is Jun–May, also ending mid-year — see `oracle.md`.) Not every Microsoft table is fiscal in
+the same way, and some figures may be stated on other bases, so capture the stated period for **each**
+metric rather than assuming.
+
+## The key constraint
+Microsoft **stopped publishing per-Azure-region PUE/WUE after 2022** (the old datacenter fact sheets
+were frozen in Dec 2024 with no new data — see the WG's conclusion on #112). What it does publish is
+**macro-regional, fiscal-year** PUE and WUE for three buckets: Global, Americas, Asia Pacific, and
+EMEA. That's the best available, so the project's approach (agreed with the user) is to **map each
+macro-regional figure onto every Azure region by continent**.
+
+## Sources
+- **Efficiency page — the PUE/WUE numbers:** `https://datacenters.microsoft.com/sustainability/efficiency/`
+  (and the annual report PDF) give the macro-regional PUE/WUE table below.
+- **Environmental Data Fact Sheet — the definitions + detailed data:** the detailed data workbook
+  PDF, e.g. `https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/microsoft/msc/documents/presentations/CSR/2026-Microsoft-Environmental-Data-Fact-Sheet-PDF.pdf`
+  (bump the year each cycle). ~28 pages of tabulated metrics with methodology footnotes: GHG emissions
+  by scope/type/**region** (Table 3), energy consumption, **renewable-energy metrics** (Table 6 —
+  "Percentage of direct renewable electricity", e.g. FY24 78% → FY25 100%, with its full definition),
+  water, waste, land. Use this for the metric definitions in `azure-<year>-metrics.md` and for the
+  gaps report. Note it's **fiscal year** and the renewable % is a market-based global figure (rule 2)
+  — don't merge it as per-region CFE; record it in the metrics doc and gaps report.
+
+The efficiency page gives a table like:
+
+| | FY-2 (→ year-2) | FY-1 (→ year-1) |
+|---|---|---|
+| Global | PUE / WUE | PUE / WUE |
+| Americas | 1.16 / 0.38 | 1.16 / 0.34 |
+| Asia Pacific | 1.25 / 0.03 | 1.28 / 0.25 |
+| EMEA | 1.16 / 0.03 | 1.16 / 0.03 |
+
+(Those numbers are the FY24/FY25 values; refresh them from the current page each year.)
+
+## Columns to populate
+- `power-usage-effectiveness`, `water-usage-effectiveness` — the macro-regional value for the region's
+  continent, mapped `FY(N)` → calendar year `N`.
+- Carry forward `cfe-region`, `em-zone-id`, `wt-region-id`, `location`, `geolocation`, and grid carbon
+  intensity from the region's prior year.
+- Leave `provider-cfe-*` blank (Microsoft's 100% CFE claim is the global market claim — see the main
+  skill's rule 2). Leave `provider-carbon-intensity-market-annual` blank unless the user decides
+  otherwise.
+
+## Region → continent map
+```
+Americas: brazilsouth, centralus, eastus, eastus2, eastus3, mexicocentral, northcentralus,
+          southcentralus, westcentralus, westus, westus3
+Asia Pacific: asiapacific, australiaeast, australiasoutheast, indiasouthcentral, newzealandnorth,
+          southeastasia, taiwannorth
+EMEA: austriaeast, denmarkeast, greececentral, italynorth, northeurope, polandcentral, spaincentral,
+          swedencentral, westeurope
+```
+(Derive the continent for any new region from its name/geography.)
+
+## Gotchas
+- The 2023 Azure rows carry *real per-region* PUE values (finer-grained than these macro averages).
+  This continent mapping is deliberately coarser — flag it clearly in the PR as an approximation, and
+  never overwrite the older per-region rows with it (rule 1).
+- Fiscal-vs-calendar year: see the "Timescale" section above — FY periods end mid-year, so this is a
+  real comparability gap, not a footnote. Record the exact `Jul–Jun` window per metric and flag it.
+- One region may appear twice in the historical data (a known duplicate `northeurope`); when carrying
+  metadata forward, dedupe by picking the most-populated prior row.

--- a/.claude/skills/annual-cloud-data-update/references/gaps-report-template.md
+++ b/.claude/skills/annual-cloud-data-update/references/gaps-report-template.md
@@ -1,0 +1,72 @@
+# Gaps-report template (`metrics/<year>/gaps-<year>.md`)
+
+One shared report per year, built from the per-vendor metrics docs. Its purpose is the project's core
+mission: show where the providers' metrics *aren't comparable* and say concretely what each should
+change so a customer could compare regions across clouds on a like-for-like basis. Be specific and
+even-handed — name the exact definitional difference, not a vague "they should do better".
+
+```markdown
+# Cross-vendor metric alignment gaps — <year>
+
+Comparability assessment of AWS, Google Cloud, Microsoft Azure, and Oracle Cloud sustainability
+metrics for <year>, against the Cloud Region Metadata schema. Built from the per-vendor metrics docs
+in this folder.
+
+## Metric-by-metric comparison
+For each metric: how each vendor defines/reports it, and the resulting incomparability.
+
+### Power Usage Effectiveness (PUE)
+| Vendor | Reports? | Granularity | Period | Boundary | Definitional notes |
+|---|---|---|---|---|---|
+| AWS | yes | per-region | Jan–Dec | operated DCs | … |
+| Google | yes | per-datacenter (→region) | annual | owned+operated | … |
+| Azure | partial | macro-region only | fiscal yr | … | no per-region since 2022 |
+| Oracle | yes | per-region | 12-mo rolling, ~88% sites | … | … |
+**Gap → ask:** <e.g. "Azure and Oracle should publish per-region, calendar-year PUE for operated
+datacenters to match AWS/Google.">
+
+### Water Usage Effectiveness (WUE)
+(same structure — note who doesn't publish it at all, e.g. Google reports water in gallons not L/kWh)
+
+### Carbon-free / renewable energy
+Distinguish **location-based, per-region, hourly** (Google CFE) from **market-based, annual, matched**
+(AWS/Azure/Oracle 100% claims that net across unconnected grids). This is the biggest comparability
+gap — state clearly which vendors publish a physically-meaningful per-region figure and which only
+publish a market claim.
+**Gap → ask:** <e.g. "AWS/Azure/Oracle should publish per-region, location-based, ideally hourly
+carbon-free-energy percentages like Google, rather than only a global market-matched claim.">
+
+### Grid carbon intensity / market carbon intensity
+(who provides per-region location-based grid data vs relies on third parties; per-grid market lists)
+
+### Reporting period & boundary
+The most-overlooked comparability gap. AWS and Google report **calendar year** (Jan 1 – Dec 31), while
+**Azure (FY Jul 1 – Jun 30) and Oracle (FY Jun 1 – May 31) report fiscal years that end in the middle
+of the calendar year.** So an Azure/Oracle "2025" figure covers roughly H2-2024 + H1-2025 and ends
+~mid-2025 — it is *not* the same window as an AWS/Google "2025" figure. State each vendor's exact
+period, and make explicit that the per-year columns in the merged table align fiscal→calendar only
+nominally. Also cover: operated vs owned+leased boundary; % of sites covered; rolling-12-month vs
+annual PUE. **Gap → ask:** vendors on fiscal reporting should additionally disclose calendar-year
+figures (or clearly state the period) so cross-cloud, same-year comparisons are like-for-like.
+
+### Metrics published by some vendors with no common schema home
+Oracle tCO₂e/$USD, embodied carbon, GHG-by-region, etc. — note whether the schema should grow to
+capture them.
+
+## Summary of recommendations per vendor
+- **AWS:** …
+- **Google:** …
+- **Azure:** …
+- **Oracle:** …
+
+## Year-over-year
+What improved or regressed in comparability since last year's gaps report.
+```
+
+## Recurring gaps to check every year
+- **Fiscal vs calendar year** — Azure and Oracle report fiscal; note the mapping and its distortion.
+- **PUE boundary/coverage** — operated vs owned, % of sites, 12-month-rolling vs Jan–Dec.
+- **WUE availability** — Google doesn't publish L/kWh WUE; Azure only macro-regional.
+- **Location vs market CFE** — the central gap; only Google gives per-region location-based CFE.
+- **Per-region vs macro/fleet** — Azure stopped per-region PUE/WUE after 2022.
+- **Per-region grid carbon** — most rely on Electricity Maps/WattTime rather than publishing their own.

--- a/.claude/skills/annual-cloud-data-update/references/google.md
+++ b/.claude/skills/annual-cloud-data-update/references/google.md
@@ -1,0 +1,49 @@
+# Google Cloud
+
+**Cadence:** Google publishes its Environmental Report ~June; the report is named for the *following*
+year (e.g. the "2026 Environmental Report" covers calendar year 2025). The machine-readable per-region
+data lands separately in a GitHub repo and can lag the PDF. Tracking issues: #159 (report link), #116,
+and #151 (a real data-quality fix — see below).
+
+## Sources
+- **Per-region hourly CFE + grid carbon intensity:**
+  `https://github.com/GoogleCloudPlatform/region-carbon-info` → `data/yearly/<year>.csv`, columns
+  `Google Cloud Region, Location, Google CFE, Grid carbon intensity (gCO2eq / kWh)`. This is the
+  authoritative per-region source and what `code/gcp-data-update.py` pulls. **Check the repo actually
+  has the new year** — it often stops a year behind the PDF, in which case Google's per-region CFE/grid
+  for the newest year simply isn't published yet; leave those columns blank and say so.
+- **Per-datacenter PUE:** the Environmental Report PDF, in the "Data center energy efficiency (PUE)"
+  table (around p.94), with a column per year 2021…latest. This is by *datacenter location*, not by
+  cloud region, so map location→region (below). Google does not publish per-region WUE (water is
+  reported in million gallons by location, not L/kWh) — leave WUE blank.
+
+## Columns to populate
+- `provider-cfe-hourly` — the `Google CFE` value from the yearly CSV. This is Google's per-region,
+  hourly-matched, location-based carbon-free-energy figure. **This is the useful column.**
+- `provider-cfe-annual` — **leave blank.** Google's only annual figure is the company-wide 100%
+  renewable *market* match, which nets across unconnected grids and isn't useful per-region (issue
+  #151 / WG position). Do not set it to `1.0`. (`code/gcp_data_update.py` in PR #156 gates this behind
+  a `GOOGLE_ANNUAL_MATCHING_CLAIM` constant — set it to `None`.)
+- `grid-carbon-intensity-average-consumption-annual` — the grid carbon intensity from the yearly CSV.
+- `power-usage-effectiveness` — from the report's per-datacenter PUE table, for regions with a
+  Google-owned datacenter. These values differ slightly year-to-year and don't always match the
+  region-carbon repo methodology, so note the source. Multi-facility metros (Singapore, Council
+  Bluffs, The Dalles, Loudoun) are ambiguous — pick the primary facility and flag it, or leave blank.
+- Carry forward `cfe-region`, `em-zone-id`, `wt-region-id`, `location`, `geolocation`.
+
+## Location → region-code map (owned datacenters with PUE)
+```
+Changhua County/Taiwan asia-east1   Inzai/Japan asia-northeast1   Singapore asia-southeast1
+Hamina/Finland europe-north1        St. Ghislain/Belgium europe-west1   Eemshaven/Netherlands europe-west4
+Quilicura/Chile southamerica-west1  Council Bluffs/Iowa us-central1  Berkeley County SC us-east1
+Loudoun County VA us-east4          Columbus/New Albany OH us-east5  Midlothian TX (Dallas) us-south1
+The Dalles/Oregon us-west1          Henderson NV (Las Vegas) us-west4
+```
+(The full region↔location list is already in the dataset's `location` column — join on it.)
+
+## The #151 lesson (verify this every year)
+Google's per-region CFE had been mis-filed: the correct `Google CFE` value ended up in
+`provider-cfe-annual` while `provider-cfe-hourly` held a stale/wrong number. The fix is to put the
+authoritative `Google CFE` into `provider-cfe-hourly` and leave `provider-cfe-annual` blank. Always
+verify the new year's `provider-cfe-hourly` equals the `Google CFE` column from the source CSV
+(a quick per-region diff — expect zero mismatches).

--- a/.claude/skills/annual-cloud-data-update/references/metrics-doc-template.md
+++ b/.claude/skills/annual-cloud-data-update/references/metrics-doc-template.md
@@ -1,0 +1,46 @@
+# Metrics-doc template (`metrics/<year>/<vendor>-<year>-metrics.md`)
+
+One per vendor per year. Goal: a self-contained record of *what the vendor published and how they
+define it*, so the merge decisions are traceable and the gaps report can be written without re-reading
+the PDFs. Quote definitions verbatim — paraphrasing loses the incomparability that this project exists
+to surface.
+
+Keep it factual; don't editorialise here (that's the gaps report's job). Do flag any metric that has
+no schema home so the gaps report can pick it up.
+
+```markdown
+# <Vendor> — <year> sustainability metrics
+
+**Sources:** <report title(s)> — <url(s)>, published <date>.
+**Reporting period — state exact start/end dates, not just a year label:** e.g. `calendar year 2025
+(Jan 1 – Dec 31 2025)`, or `FY2025 (Jul 1 2024 – Jun 30 2025)` for Azure, `FY2025 (Jun 1 2024 – May 31
+2025)` for Oracle. Fiscal-year vendors **end mid-calendar-year**, so their "year N" is not the same
+window as a calendar-year vendor's "year N" — this is a first-class comparability fact, capture it up
+front. If different tables in the same report use different periods (e.g. calendar-year PUE but
+fiscal-year emissions), note the period **per metric** in the table below.
+Coverage boundary: <operated | owned+leased | % of sites | region set>.
+
+## Metric definitions (quoted)
+| Metric | Vendor's definition (verbatim) | Period | Method (location/market, hourly/annual, per-region/fleet) | RTC column | Merge? |
+|---|---|---|---|---|---|
+| PUE | "<quote>" | <Jan–Dec 20XX> | per-region, 12-mo … | power-usage-effectiveness | yes |
+| WUE | "<quote>" | … | per-region, L/kWh | water-usage-effectiveness | yes |
+| Carbon-free / renewable % | "<quote>" | … | <market, global> or <location, hourly, per-region> | provider-cfe-* / market | yes/no + why |
+| <metric with no schema home> | "<quote>" | … | … | — | no — see gaps |
+
+## Per-region values
+| region-code | PUE | WUE | CFE/RE% | market carbon | grid carbon | notes |
+|---|---|---|---|---|---|---|
+| … | | | | | | |
+(Only include what the vendor actually discloses; leave cells blank otherwise. Note where a value is
+carried forward vs freshly disclosed.)
+
+## Fleet / global figures (context, not merged per-region)
+- Global PUE / WUE / renewable %: …
+
+## Metrics with no home in the RTC schema
+- <e.g. tCO₂e/$USD, embodied carbon, GHG-by-region, water in gallons> — recorded for the gaps report.
+
+## Notes & caveats
+- Restatements of prior years, coverage changes, fiscal-vs-calendar mismatch, ambiguous mappings, etc.
+```

--- a/.claude/skills/annual-cloud-data-update/references/oracle.md
+++ b/.claude/skills/annual-cloud-data-update/references/oracle.md
@@ -1,0 +1,61 @@
+# Oracle Cloud Infrastructure (OCI)
+
+**Cadence:** Oracle publishes the "Clean Cloud OCI Data Sheet" ~December, on a **fiscal year that runs
+June 1 – May 31**; e.g. **FY2025 = Jun 2024 – May 2025** (ends mid-2025, not Dec 31). The sheet (Dec
+2025) has FY2024 and FY2025 columns. Like Azure, Oracle's fiscal periods end mid-calendar-year, so its
+"FY25" doesn't line up with AWS/Google calendar-2025 — map `FY(N) → year N` but record the exact window
+(`Jun 2024–May 2025`) in the metrics doc and flag the offset in `gaps-<year>.md`. A separate, older CY
+report carries the per-region PUE (which *is* calendar-year — note the mixed basis). Tracking issue: #86.
+Provider name in the CSV: `Oracle Cloud Infrastructure`.
+
+## Sources (three, joined on region identifier)
+1. **Renewable-electricity % per region, FY24/FY25:**
+   `https://www.oracle.com/a/ocom/docs/corporate/citizenship/clean-cloud-oci.pdf` — a per-region table
+   grouped by continent, with `RE%` and a `tCO₂e/$USD` intensity metric (the latter has **no schema
+   home** — ignore it). It also lists the 3-letter region key (IAD, FRA, NRT, …).
+2. **CY PUE + RE% per region:** Oracle's CY sustainability report (the older one). This is the only
+   source of Oracle per-region **PUE**.
+3. **Electricity Maps grid mapping** (`cfe-region`, `em-zone-id`, `wt-region-id`, `geolocation`, grid
+   carbon intensity): assembled in the project's OCI working data (a Google Sheet linked from #86,
+   with an `IF Source` tab already in the 24-column schema and an `Oracle Cloud` tab holding RE%/PUE
+   keyed by identifier). Export the sheet as xlsx (`.../export?format=xlsx`) and read with `openpyxl`.
+
+Join all three on the OCI **region identifier**. The 3-letter key → identifier mapping comes from
+Oracle's official list, `https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm`.
+
+## Columns to populate
+- `provider-cfe-annual` — the per-region **renewable-electricity %** (as a 0–1 proportion). Oracle's
+  RE% genuinely varies by region (0–100%), so it *is* legitimate per-region data — keep it here. (It
+  is market-based matching, unlike Google's location-based hourly CFE; note that in the PR.)
+- `power-usage-effectiveness` — CY per-region PUE, on the CY-year rows only. Oracle hasn't disclosed
+  newer per-region PUE, so leave PUE blank on the FY-derived (2024/2025) rows rather than inventing it.
+  Treat a PUE of `0` in the source as "not disclosed" (blank).
+- `cfe-region`, `em-zone-id`, `wt-region-id`, `geolocation`, grid carbon intensity — from the
+  Electricity Maps mapping (`IF Source`); carry the year-independent values across all years.
+- `provider-carbon-intensity-market-annual` — leave **blank** (Oracle's 100% is market-based matching,
+  the global-claim family; see rule 2). Unlike AWS, Oracle doesn't publish a per-grid within-grid list,
+  so don't set market = 0.
+
+## Region key → identifier examples
+```
+IAD us-ashburn-1   ORD us-chicago-1   PHX us-phoenix-1   SJC us-sanjose-1
+YUL ca-montreal-1  YYZ ca-toronto-1   GRU sa-saopaulo-1  VCP sa-vinhedo-1  SCL sa-santiago-1
+FRA eu-frankfurt-1 CDG eu-paris-1     LHR uk-london-1    CWL uk-cardiff-1  AMS eu-amsterdam-1
+NRT ap-tokyo-1     KIX ap-osaka-1     SIN ap-singapore-1 SYD ap-sydney-1   ICN ap-seoul-1
+```
+Gov/DoD identifiers aren't in the commercial list; from the working sheet:
+`RIC us-gov-ashburn-1, PIA us-gov-chicago-1, TUS us-gov-phoenix-1, LFI us-langley-1,
+LUF us-luke-1, LTN uk-gov-london-1, BRS uk-gov-cardiff-1`.
+
+## Gov / DoD regions
+Include them if the user wants them. They have RE%/PUE but no Electricity Maps zone in the working
+data — assign each the grid zone + carbon intensity of the **co-located commercial region** in the
+same metro (they share the physical grid): `us-gov-ashburn-1`/`us-langley-1` ← `us-ashburn-1`,
+`us-gov-chicago-1` ← `us-chicago-1`, `us-gov-phoenix-1`/`us-luke-1` ← `us-phoenix-1`,
+`uk-gov-london-1` ← `uk-london-1`, `uk-gov-cardiff-1` ← `uk-cardiff-1`.
+
+## Gotchas
+- Fiscal year (Jun–May) mapped FY24→2024, FY25→2025 — state the caveat.
+- Regions where FY24 RE% is `N/A` (not yet active) get no 2024 row; only add years the sheet covers.
+- Regions in Oracle's data but not resolvable to an identifier (e.g. a Dallas or Salt Lake City entry
+  with no key, or the Canberra dedicated region with no RE%/PUE) — skip and note for the user.


### PR DESCRIPTION
## Summary
Adds a Claude Code **skill** under `.claude/skills/annual-cloud-data-update/` that documents and drives the yearly refresh of `Cloud_Region_Metadata.csv` when AWS, Google, Azure and Oracle publish their sustainability data. It captures the institutional knowledge for doing this cleanly so future updates are repeatable rather than rediscovered each year.

## Three-phase workflow it encodes
1. **Extract** each vendor's metrics **and their verbatim metric definitions** into `metrics/<year>/<vendor>-<year>-metrics.md` — including downloading AWS's **~32 per-region fact sheets** and Microsoft's **detailed Environmental Data Fact Sheet**, so the definitions (not just the numbers) are recorded.
2. **Merge** only metrics whose definition genuinely fits the schema column — additively, preserving CRLF, never modifying an already-published year.
3. **Gaps report** — `metrics/<year>/gaps-<year>.md`, a cross-vendor alignment analysis of what each vendor should change for comparable metrics (serves the project's lobbying mission).

## Key rules it bakes in
- **Per-region physical data only, not the global market claim** — don't populate the CFE columns with a uniform "100% renewable" market claim; AWS's per-grid renewable list is per-region and OK.
- **Fiscal-vs-calendar timescale** — Azure (Jul–Jun) and Oracle (Jun–May) fiscal years **end mid-calendar-year**, so their "2025" isn't a calendar-2025 window; record exact periods and flag in the gaps report.
- The practical traps: CRLF line endings, `awk` mis-splitting the quoted `geolocation` comma, the unreliable AWS scraper, `region-carbon-info` lagging Google's PDF, and the additive-only (`removed: 0`) verification.

## Structure
```
.claude/skills/annual-cloud-data-update/
├── SKILL.md
└── references/{aws,google,azure,oracle}.md
    + metrics-doc-template.md, gaps-report-template.md
```
Contains no data changes — purely the process documentation. Pairs with the 2025 data PR (#162) and the Oracle PR (#163).

🤖 Generated with [Claude Code](https://claude.com/claude-code)